### PR TITLE
fix: standardize SetUserAttributes signatures and add HaveSurveys docs

### DIFF
--- a/Documentation~/HOWTO.md
+++ b/Documentation~/HOWTO.md
@@ -1,4 +1,3 @@
-
 # **GottaAsk SDK - Unity**
 
 The `GottaAskSDK` provides functionality for integrating surveys and ads into Unity projects, supporting Android and iOS platforms. Below is an overview of the API, usage, and platform-specific implementations.
@@ -85,6 +84,21 @@ private static void SetOnSurveyCompletedDelegate()
   - **Editor/iOS**: Logs the action.
   - **Android**: Sets a callback proxy for receiving events from the Android bridge.
 
+### **HaveSurveys**
+```csharp
+public static IEnumerator<object> HaveSurveys(System.Action<bool> callback)
+```
+- Checks if there are surveys available to be shown. Can be called before showing a survey.
+- **Parameters**:
+  - `callback`: Action that receives a boolean indicating if surveys are available.
+- **Returns**:
+  - An IEnumerator for coroutine support.
+
+#### **Platform-Specific Behavior**
+- **Editor**: Returns false through the callback.
+- **Android**: Makes an API request to check for available surveys.
+- **iOS**: Logs the action (functionality to be implemented).
+
 ---
 
 ## **Usage Example**
@@ -114,7 +128,17 @@ public class GottaAskDemo : MonoBehaviour
 
     public void ShowSurvey()
     {
-        GottaAskSDK.ShowSurvey();
+      // Check if surveys are available before showing
+      StartCoroutine(GottaAskSDK.HaveSurveys((hasSurveys) => {
+          if (hasSurveys)
+          {
+              GottaAskSDK.ShowSurvey();
+          }
+          else
+          {
+              Debug.Log("No surveys available at the moment");
+          }
+      }));
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ In order to use this package in your application, contact [fredrik@advey.io](mai
 
 **Currently only supporting Android!**
 
-- Unity package version: `0.0.10`
+- Unity package version: `0.0.11`
 - Android package version: `0.1.1`
 - iOS package version: `N/A`
 

--- a/Runtime/GottaAskSDK.cs
+++ b/Runtime/GottaAskSDK.cs
@@ -219,14 +219,19 @@ namespace GottaAsk
             DebugLogger.Log("iOS: Init");
         }
 
-        public static void SetUserAttributes(int age = "", string country = "", int income = "")
+        public static void SetUserAttributes(int age = 0, string country = null, int income = 0)
         {
             DebugLogger.Log("iOS: SetUserAttributes");
         }
 
-        public static void SetUserAttributes(Dictionary<string, string> attributes)
+        public static void SetUserAttributes(GottaAskDemographicData data)
         {
             DebugLogger.Log("iOS: SetUserAttributes");
+        }
+
+        private static void AddDemographicData(GottaAskDemographicData data)
+        {
+            DebugLogger.Log("iOS: AddDemographicData");
         }
 
         private static void SetOnSurveyCompletedDelegate()

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.advey.gottaask",
   "displayName": "GottaAsk SDK",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "unity": "2021.3",
   "type": "library",
   "description": "GottaAsk Unity is a Unity package for integrating GottaAsk User Survey ads into your Unity Project. This package supports Unity based games running on Android and iOS.",


### PR DESCRIPTION
- Fix iOS SetUserAttributes method signature to match Android implementation
- Change age/income parameters from string to int with proper defaults (0)
- Replace Dictionary<string, string> overload with GottaAskDemographicData parameter
- Add missing AddDemographicData method for iOS platform
- Update HOWTO.md with HaveSurveys method documentation and usage example